### PR TITLE
Use zendesk actions

### DIFF
--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - uses: zendesk/checkout@v2
+    - name: Setup Ruby
+      uses: zendesk/setup-ruby@v1
       with:
-        version: 2.6.x
+        ruby-version: 2.6
 
     - name: Publish to RubyGems
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,9 @@ jobs:
         - jruby-9.2.11.1
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: zendesk/checkout@v2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: zendesk/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
     - name: Install dependencies
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: zendesk/checkout@v2
     - name: Install dependencies
       uses: docker://jruby:1.7.27
       with:


### PR DESCRIPTION
We blocked 3rd party actions, which includes the github ones. We need to use our cloned actions inside zendesk org