### PR TITLE
Run tests on Ruby 3.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
+        - 2.3.8
+        - 2.4.10
+        - 2.5.9
         - 2.7.7
         - 3.0.5
         - 3.1.3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby-version:
         - 2.7.7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,14 +27,3 @@ jobs:
       run: bundle install
     - name: Run tests
       run: bundle exec rspec
-
-  test-jruby:
-    name: test (jruby-1.7.27)
-    runs-on: ubuntu-latest
-    
-    steps:
-    - uses: zendesk/checkout@v3
-    - name: Install dependencies
-      uses: docker://jruby:1.7.27
-      with:
-        args: /bin/sh -c "bundle install && bundle exec rspec"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - 2.7.0
-        - 2.5.8
-        - 2.3.8
-        - jruby-9.2.11.1
+        - 2.7.7
+        - 3.0.5
+        - 3.1.3
+        - 3.2.1
 
     steps:
     - uses: zendesk/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         - jruby-9.2.11.1
 
     steps:
-    - uses: zendesk/checkout@v2
+    - uses: zendesk/checkout@v3
     - name: Set up Ruby
       uses: zendesk/setup-ruby@v1
       with:
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: zendesk/checkout@v2
+    - uses: zendesk/checkout@v3
     - name: Install dependencies
       uses: docker://jruby:1.7.27
       with:

--- a/method_struct.gemspec
+++ b/method_struct.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   end
   
   spec.add_development_dependency "rake", ">= 10.0"
-  spec.add_development_dependency "rspec", "~> 2.14.1"
+  spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/spec/method_struct_spec.rb
+++ b/spec/method_struct_spec.rb
@@ -148,11 +148,11 @@ describe MethodStruct do
       let(:struct) { MethodStruct.new(:a, :b) }
 
       it "is equal for equal arguments" do
-        expect(struct.new(argument1, argument2) == struct.new(argument1, argument2)).to be_true
+        expect(struct.new(argument1, argument2) == struct.new(argument1, argument2)).to be true
       end
 
       it "is eql for equal arguments" do
-        expect(struct.new(argument1, argument2).eql?(struct.new(argument1, argument2))).to be_true
+        expect(struct.new(argument1, argument2).eql?(struct.new(argument1, argument2))).to be true
       end
 
       it "has equal hashes for equal arguments" do
@@ -160,11 +160,11 @@ describe MethodStruct do
       end
 
       it "is unequal for unequal arguments" do
-        expect(struct.new(argument1, argument2) == struct.new(argument2, argument1)).to be_false
+        expect(struct.new(argument1, argument2) == struct.new(argument2, argument1)).to be false
       end
 
       it "is unequal for unequal arguments" do
-        expect(struct.new(argument1, argument2).eql?(struct.new(argument2, argument1))).to be_false
+        expect(struct.new(argument1, argument2).eql?(struct.new(argument2, argument1))).to be false
       end
 
       it "is unequal for different MethodsStruct classes" do


### PR DESCRIPTION
Adds Ruby 3.x to the test matrix, updates rspec to support this.
